### PR TITLE
refactor: use tf wrapper after std out fix

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -77,7 +77,7 @@ jobs:
                 "plan_outcome_destroy":(map(select(.=="delete")) | length)
               } | to_entries | map("\(.key)=\(.value)") | @sh
             '
-            eval "export $(${TERRAFORM_CLI_PATH}/terraform-bin show -json tfplan | jq -r "${jq_plan_parser}")"
+            eval "export $(terraform show -json tfplan | jq -r "${jq_plan_parser}")"
             {
               printf "has_changes=yes\n";
               printf "add=%s\n" "${plan_outcome_add}"


### PR DESCRIPTION
#41 updated `setup-terraform` which included a fix to the terraform wrapper, which returns std out correctly.

This means we don't need to use the binary directly.